### PR TITLE
Homebrew dirs permissions and puppet-lint fixes

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,3 +1,4 @@
+# @class homebrew::install
 class homebrew::install {
 
   $brew_sys_folders = [

--- a/manifests/installarm.pp
+++ b/manifests/installarm.pp
@@ -1,9 +1,10 @@
+# @class homebrew::installarm
 class homebrew::installarm {
 
   $homebrew_prefix = '/opt/homebrew'
-  $homebrew_repository = "${homebrew_prefix}"
+  $homebrew_repository = $homebrew_prefix
 
-  $homebrew_missing_folders = [$homebrew_prefix, "${homebrew_prefix}/bin"]
+  $homebrew_missing_folders = [$homebrew_prefix]
 
   file { $homebrew_missing_folders:
     ensure => directory,
@@ -12,6 +13,7 @@ class homebrew::installarm {
   }
 
   $brew_sys_folders = [
+    "${homebrew_prefix}/bin",
     "${homebrew_prefix}/etc",
     "${homebrew_prefix}/include",
     "${homebrew_prefix}/lib",
@@ -24,6 +26,7 @@ class homebrew::installarm {
         ensure => directory,
         owner  => $homebrew::user,
         group  => $homebrew::group,
+        mode   => '0775',
       }
     }
   }


### PR DESCRIPTION
This MR fixes some minor puppet-lint warnings and, most importantly, idempotency problems in setting Homebrew dirs permissions resulting in repeated resources changes at every puppet run:
```
Notice: /Stage[main]/Homebrew::Installarm/File[/opt/homebrew/bin]/mode: mode changed '0775' to '0755' (corrective)
Notice: /Stage[main]/Homebrew::Installarm/File[/opt/homebrew/etc]/mode: mode changed '0775' to '0755' (corrective)
Notice: /Stage[main]/Homebrew::Installarm/File[/opt/homebrew/include]/mode: mode changed '0775' to '0755' (corrective)
Notice: /Stage[main]/Homebrew::Installarm/File[/opt/homebrew/lib]/mode: mode changed '0775' to '0755' (corrective)
Notice: /Stage[main]/Homebrew::Installarm/File[/opt/homebrew/lib/pkgconfig]/mode: mode changed '0775' to '0755' (corrective)
Notice: /Stage[main]/Homebrew::Installarm/File[/opt/homebrew/var]/mode: mode changed '0775' to '0755' (corrective)
Notice: /Stage[main]/Homebrew::Installarm/Exec[brew-chmod-sys-/opt/homebrew/bin]/returns: executed successfully (corrective)
Info: /Stage[main]/Homebrew::Installarm/Exec[brew-chmod-sys-/opt/homebrew/bin]: Scheduling refresh of Exec[set-/opt/homebrew/bin-directory-inherit]
Notice: /Stage[main]/Homebrew::Installarm/Exec[set-/opt/homebrew/bin-directory-inherit]: Triggered 'refresh' from 1 event
Notice: /Stage[main]/Homebrew::Installarm/Exec[brew-chmod-sys-/opt/homebrew/include]/returns: executed successfully (corrective)
Info: /Stage[main]/Homebrew::Installarm/Exec[brew-chmod-sys-/opt/homebrew/include]: Scheduling refresh of Exec[set-/opt/homebrew/include-directory-inherit]
Notice: /Stage[main]/Homebrew::Installarm/Exec[set-/opt/homebrew/include-directory-inherit]: Triggered 'refresh' from 1 event
Notice: /Stage[main]/Homebrew::Installarm/Exec[brew-chmod-sys-/opt/homebrew/lib]/returns: executed successfully (corrective)
Info: /Stage[main]/Homebrew::Installarm/Exec[brew-chmod-sys-/opt/homebrew/lib]: Scheduling refresh of Exec[set-/opt/homebrew/lib-directory-inherit]
Notice: /Stage[main]/Homebrew::Installarm/Exec[set-/opt/homebrew/lib-directory-inherit]: Triggered 'refresh' from 1 event
Notice: /Stage[main]/Homebrew::Installarm/Exec[brew-chmod-sys-/opt/homebrew/etc]/returns: executed successfully (corrective)
Info: /Stage[main]/Homebrew::Installarm/Exec[brew-chmod-sys-/opt/homebrew/etc]: Scheduling refresh of Exec[set-/opt/homebrew/etc-directory-inherit]
Notice: /Stage[main]/Homebrew::Installarm/Exec[set-/opt/homebrew/etc-directory-inherit]: Triggered 'refresh' from 1 event
Notice: /Stage[main]/Homebrew::Installarm/Exec[brew-chmod-sys-/opt/homebrew/var]/returns: executed successfully (corrective)
Info: /Stage[main]/Homebrew::Installarm/Exec[brew-chmod-sys-/opt/homebrew/var]: Scheduling refresh of Exec[set-/opt/homebrew/var-directory-inherit]
Notice: /Stage[main]/Homebrew::Installarm/Exec[set-/opt/homebrew/var-directory-inherit]: Triggered 'refresh' from 1 event
Notice: /Stage[main]/Homebrew::Installarm/File[/opt/homebrew/var/homebrew]/mode: mode changed '0775' to '0755' (corrective)
```
