### PR TITLE
Fix Rosetta 2 breakage

### DIFF
--- a/lib/puppet/provider/package/brew.rb
+++ b/lib/puppet/provider/package/brew.rb
@@ -36,6 +36,7 @@ Puppet::Type.type(:package).provide(:brew, :parent => Puppet::Provider::Package)
 
     custom_env = {'HOME' => home}
     custom_env['HOMEBREW_CHANGE_ARCH_TO_ARM'] = '1' if Facter.value(:has_arm64)
+    cmd = ["arch", "-arm64"].append(cmd) if Facter.value(:has_arm64)
 
     if Puppet.features.bundled_environment?
       Bundler.with_clean_env do

--- a/lib/puppet/provider/package/brewcask.rb
+++ b/lib/puppet/provider/package/brewcask.rb
@@ -36,6 +36,7 @@ Puppet::Type.type(:package).provide(:brewcask, :parent => Puppet::Provider::Pack
 
     custom_env = {'HOME' => home}
     custom_env['HOMEBREW_CHANGE_ARCH_TO_ARM'] = '1' if Facter.value(:has_arm64)
+    cmd = ["arch", "-arm64"].append(cmd) if Facter.value(:has_arm64)
 
     if Puppet.features.bundled_environment?
       Bundler.with_clean_env do

--- a/lib/puppet/provider/package/homebrew.rb
+++ b/lib/puppet/provider/package/homebrew.rb
@@ -36,6 +36,7 @@ Puppet::Type.type(:package).provide(:homebrew, :parent => Puppet::Provider::Pack
 
     custom_env = {'HOME' => home}
     custom_env['HOMEBREW_CHANGE_ARCH_TO_ARM'] = '1' if Facter.value(:has_arm64)
+    cmd = ["arch", "-arm64"].append(cmd) if Facter.value(:has_arm64)
 
     if Puppet.features.bundled_environment?
       Bundler.with_clean_env do

--- a/lib/puppet/provider/package/tap.rb
+++ b/lib/puppet/provider/package/tap.rb
@@ -34,6 +34,7 @@ Puppet::Type.type(:package).provide(:tap, :parent => Puppet::Provider::Package) 
 
     custom_env = {'HOME' => home}
     custom_env['HOMEBREW_CHANGE_ARCH_TO_ARM'] = '1' if Facter.value(:has_arm64)
+    cmd = ["arch", "-arm64"].append(cmd) if Facter.value(:has_arm64)
 
     if Puppet.features.bundled_environment?
       Bundler.with_clean_env do


### PR DESCRIPTION
```
Running `brew update --auto-update`...
==> Auto-updated Homebrew!
Updated 1 tap (homebrew/core).

You have 34 outdated formulae and 3 outdated casks installed.
You can upgrade them with brew upgrade
or list them with brew outdated.

Error: Cannot install under Rosetta 2 in ARM default prefix (/opt/homebrew)!
To rerun under ARM use:
    arch -arm64 brew install ...
To install under x86_64, install Homebrew into /usr/local.
```